### PR TITLE
fix: prevent permissions issue by adding dir structure, cache, temp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /dist
 /node_modules
 /build
-/.afj
 
 # Logs
 logs

--- a/credo/cache/.afj/.gitignore
+++ b/credo/cache/.afj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/credo/data/.afj/.gitignore
+++ b/credo/data/.afj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/credo/temp/.afj/.gitignore
+++ b/credo/temp/.afj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/devops/charts/server/README.md
+++ b/devops/charts/server/README.md
@@ -3,5 +3,5 @@ helm install vdr-proxy ./devops/charts/server -f ./devops/charts/server/values_d
 ```
 
 ```console
-helm template vdr-proxy ./devops/charts/server -f ./devops/charts/server values_dev.yaml | oc apply -n c2a2c4-dev -f -
+helm template vdr-proxy ./devops/charts/server -f ./devops/charts/server/values_dev.yaml | oc apply -n c2a2c4-dev -f -
 ```

--- a/devops/charts/server/README.md
+++ b/devops/charts/server/README.md
@@ -1,7 +1,9 @@
+Initial:
 ```console
 helm install vdr-proxy ./devops/charts/server -f ./devops/charts/server/values_dev.yaml
 ```
 
+Afterwards:
 ```console
-helm template vdr-proxy ./devops/charts/server -f ./devops/charts/server/values_dev.yaml | oc apply -n c2a2c4-dev -f -
+helm upgrade vdr-proxy ./devops/charts/server -f ./devops/charts/server/values_dev.yaml
 ```

--- a/devops/charts/server/templates/deployment.yaml
+++ b/devops/charts/server/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             periodSeconds: 10
           volumeMounts:
             - name: cache-volume
-              mountPath: /app/cache
+              mountPath: /app/credo
           env:
             - name: PORT
               value: {{.Values.env.PORT | quote}}

--- a/src/helpers/agent.ts
+++ b/src/helpers/agent.ts
@@ -24,7 +24,9 @@ import { WebSocket } from 'ws'
 class CustomFileSystem extends NodeFileSystem {
   public constructor() {
     super({
-      baseDataPath: `${process.cwd()}/cache`,
+      baseDataPath: `${process.cwd()}/credo/data`,
+      baseCachePath: `${process.cwd()}/credo/cache`,
+      baseTempPath: `${process.cwd()}/credo/tmp`,
     })
   }
 }


### PR DESCRIPTION
I'm fairly confident this will fix the issue as it works when I run `docker run -p 3000:3000 'image_name'`, hit a proxy route,  initialize the agent, and receive the correct response. The only thing I'm unsure of is the volume mount setup, but there's only really one way to test that.