### PR TITLE
feat: added patch to configure indy-vdr cache

### DIFF
--- a/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch
+++ b/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch
@@ -1,0 +1,80 @@
+diff --git a/build/NodeJSIndyVdr.d.ts b/build/NodeJSIndyVdr.d.ts
+index 75b6201a0eaaaafeb0d6ea260d912e9ff5ad3386..f63395d2b83f6a3ba7ee75d8dbac1abbbda43d27 100644
+--- a/build/NodeJSIndyVdr.d.ts
++++ b/build/NodeJSIndyVdr.d.ts
+@@ -12,6 +12,10 @@ export declare class NodeJSIndyVdr implements IndyVdr {
+     setCacheDirectory(options: {
+         path: string;
+     }): void;
++    setLedgerTxnCache(options) {
++        const { capacity, expiry_offset_ms, path } = (0, ffi_1.serializeArguments)(options);
++        this.handleError(this.nativeIndyVdr.indy_vdr_set_ledger_txn_cache(capacity, expiry_offset_ms, path));
++    }
+     setDefaultLogger(): void;
+     setProtocolVersion(options: {
+         version: number;
+diff --git a/build/NodeJSIndyVdr.js b/build/NodeJSIndyVdr.js
+index 5d96ddf79179ef2a0c7beb55a2c9972b713e6106..51f8d9911fb5cd75818774a65774e2307672278d 100644
+--- a/build/NodeJSIndyVdr.js
++++ b/build/NodeJSIndyVdr.js
+@@ -82,6 +82,10 @@ class NodeJSIndyVdr {
+         const { path } = (0, ffi_1.serializeArguments)(options);
+         this.handleError(this.nativeIndyVdr.indy_vdr_set_cache_directory(path));
+     }
++    setLedgerTxnCache(options) {
++        const { capacity, expiry_offset_ms, path } = (0, ffi_1.serializeArguments)(options);
++        this.handleError(this.nativeIndyVdr.indy_vdr_set_ledger_txn_cache(capacity, expiry_offset_ms, path));
++    }
+     setDefaultLogger() {
+         this.handleError(this.nativeIndyVdr.indy_vdr_set_default_logger());
+     }
+diff --git a/build/library/NativeBindings.d.ts b/build/library/NativeBindings.d.ts
+index 3f5169052911cc5df56b940036943ffc71bf7550..c6157c861c111212033f4fa760b3910c7314403c 100644
+--- a/build/library/NativeBindings.d.ts
++++ b/build/library/NativeBindings.d.ts
+@@ -2,6 +2,7 @@ import type { ByteBuffer } from '../ffi';
+ export interface NativeMethods {
+     indy_vdr_set_config: (arg0: string) => number;
+     indy_vdr_set_cache_directory: (arg0: string) => number;
++    indy_vdr_set_ledger_txn_cache: (arg0: number, arg1: number, arg2?: string) => number;
+     indy_vdr_set_default_logger: () => number;
+     indy_vdr_set_protocol_version: (arg0: number) => number;
+     indy_vdr_set_socks_proxy: (arg0: string) => number;
+diff --git a/build/library/bindings.d.ts b/build/library/bindings.d.ts
+index a9fcbc5017760678ca474a8b243409b9714183a3..2eeb7fff2441ea09ba26fbb7cc0f95679e134a64 100644
+--- a/build/library/bindings.d.ts
++++ b/build/library/bindings.d.ts
+@@ -5,6 +5,7 @@ export declare const nativeBindings: {
+     readonly indy_vdr_set_socks_proxy: readonly ["int64", readonly ["string"]];
+     readonly indy_vdr_version: readonly ["string", readonly []];
+     readonly indy_vdr_get_current_error: readonly ["int64", readonly [import("@2060.io/ref-napi").Type<import("@2060.io/ref-napi").Pointer<string | null>>]];
++    readonly indy_vdr_set_ledger_txn_cache: readonly ["int64", readonly ["int64", "int64", "string"]];
+     readonly indy_vdr_build_acceptance_mechanisms_request: readonly ["int64", readonly ["string", "string", "string", "string", "int64*"]];
+     readonly indy_vdr_build_attrib_request: readonly ["int64", readonly ["string", "string", "string", "string", "string", "int64*"]];
+     readonly indy_vdr_build_cred_def_request: readonly ["int64", readonly ["string", "string", "int64*"]];
+diff --git a/build/library/bindings.js b/build/library/bindings.js
+index c1684622808a1400e366a05107a92ad5f56c5708..c57292866317b0feedb6064c8de9fbf002f7fb50 100644
+--- a/build/library/bindings.js
++++ b/build/library/bindings.js
+@@ -10,6 +10,8 @@ exports.nativeBindings = {
+     indy_vdr_set_socks_proxy: [ffi_1.FFI_ERROR_CODE, [ffi_1.FFI_STRING]],
+     indy_vdr_version: [ffi_1.FFI_STRING, []],
+     indy_vdr_get_current_error: [ffi_1.FFI_ERROR_CODE, [ffi_1.FFI_STRING_PTR]],
++    // cache
++    indy_vdr_set_ledger_txn_cache: [ffi_1.FFI_ERROR_CODE, [ffi_1.FFI_INT64, ffi_1.FFI_INT64, ffi_1.FFI_STRING]],
+     // requests
+     indy_vdr_build_acceptance_mechanisms_request: [
+         ffi_1.FFI_ERROR_CODE,
+diff --git a/package.json b/package.json
+index 2f91c2128b7eb874f977f175a51472c511b3b937..3409349df5b958043711910851ec6c3a59174ff1 100644
+--- a/package.json
++++ b/package.json
+@@ -50,7 +50,7 @@
+   "binary": {
+     "module_name": "indy_vdr",
+     "module_path": "native",
+-    "remote_path": "v0.4.1",
++    "remote_path": "v0.4.3",
+     "host": "https://github.com/hyperledger/indy-vdr/releases/download/",
+     "package_name": "library-{platform}-{arch}.tar.gz"
+   },

--- a/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch
+++ b/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch
@@ -1,0 +1,16 @@
+diff --git a/build/types/IndyVdr.d.ts b/build/types/IndyVdr.d.ts
+index 99f5d50a851462c8c41e52ceb49795feebce0b4e..3aa7890e1f3c422daa6ec82fd6b42d0b924d18b5 100644
+--- a/build/types/IndyVdr.d.ts
++++ b/build/types/IndyVdr.d.ts
+@@ -11,6 +11,11 @@ export interface IndyVdr {
+     setCacheDirectory(options: {
+         path: string;
+     }): void;
++    setLedgerTxnCache(options: {
++        capacity: number;
++        expiry_offset_ms: number;
++        path?: string;
++    }): void;
+     setDefaultLogger(): void;
+     setProtocolVersion(options: {
+         version: number;

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "@hyperledger/anoncreds-shared": "0.2.2",
     "@hyperledger/aries-askar-nodejs": "0.2.1",
     "@hyperledger/aries-askar-shared": "0.2.1",
-    "@hyperledger/indy-vdr-nodejs": "0.2.2",
-    "@hyperledger/indy-vdr-shared": "0.2.2",
+    "@hyperledger/indy-vdr-nodejs": "patch:@hyperledger/indy-vdr-nodejs@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch",
+    "@hyperledger/indy-vdr-shared": "patch:@hyperledger/indy-vdr-shared@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch",
     "@nestjs/common": "^10.3.9",
     "@nestjs/core": "^10.3.9",
     "@nestjs/platform-express": "^10.0.0",
@@ -85,6 +85,8 @@
   "packageManager": "yarn@4.3.1",
   "resolutions": {
     "@hyperledger/aries-askar-nodejs": "0.2.1",
-    "@hyperledger/aries-askar-shared": "0.2.1"
+    "@hyperledger/aries-askar-shared": "0.2.1",
+    "@hyperledger/indy-vdr-nodejs@npm:^0.2.2": "patch:@hyperledger/indy-vdr-nodejs@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch",
+    "@hyperledger/indy-vdr-shared@npm:0.2.2": "patch:@hyperledger/indy-vdr-shared@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch"
   }
 }

--- a/src/helpers/agent.ts
+++ b/src/helpers/agent.ts
@@ -44,6 +44,7 @@ export function setupAgent(options: {
   networks: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]]
   logger?: Logger
 }) {
+  indyVdr.setLedgerTxnCache({ capacity: 1000, expiry_offset_ms: 1000 * 60 * 60 * 24 *7, path: '/tmp/indy-vdr-cache' })
   return new Agent({
     config: {
       label: 'Indy VDR Proxy',

--- a/src/helpers/agent.ts
+++ b/src/helpers/agent.ts
@@ -44,7 +44,11 @@ export function setupAgent(options: {
   networks: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]]
   logger?: Logger
 }) {
-  indyVdr.setLedgerTxnCache({ capacity: 1000, expiry_offset_ms: 1000 * 60 * 60 * 24 *7, path: '/tmp/indy-vdr-cache' })
+  indyVdr.setLedgerTxnCache({
+    capacity: 1000,
+    expiry_offset_ms: 1000 * 60 * 60 * 24 * 7,
+    path: '/tmp/indy-vdr-cache',
+  })
   return new Agent({
     config: {
       label: 'Indy VDR Proxy',

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,7 +980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperledger/indy-vdr-nodejs@npm:0.2.2, @hyperledger/indy-vdr-nodejs@npm:^0.2.2":
+"@hyperledger/indy-vdr-nodejs@npm:0.2.2":
   version: 0.2.2
   resolution: "@hyperledger/indy-vdr-nodejs@npm:0.2.2"
   dependencies:
@@ -994,10 +994,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hyperledger/indy-vdr-nodejs@patch:@hyperledger/indy-vdr-nodejs@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch":
+  version: 0.2.2
+  resolution: "@hyperledger/indy-vdr-nodejs@patch:@hyperledger/indy-vdr-nodejs@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch::version=0.2.2&hash=f3ea0c"
+  dependencies:
+    "@2060.io/ffi-napi": "npm:^4.0.9"
+    "@2060.io/ref-napi": "npm:^3.0.6"
+    "@hyperledger/indy-vdr-shared": "npm:0.2.2"
+    "@mapbox/node-pre-gyp": "npm:^1.0.10"
+    ref-array-di: "npm:^1.2.2"
+    ref-struct-di: "npm:^1.1.1"
+  checksum: 10c0/b61bb9826136870dc38d62f8cd0e796c5d831d98bd693f893d0bade18c2ae13e91362cbdaf29ddf284fd2ee0405e0a79aa43fa9a1f7b378dd4f59afbd34901d6
+  languageName: node
+  linkType: hard
+
 "@hyperledger/indy-vdr-shared@npm:0.2.2":
   version: 0.2.2
   resolution: "@hyperledger/indy-vdr-shared@npm:0.2.2"
   checksum: 10c0/7e3b98966ba704939c432f7f71ed9f25c9370f2b73037553781ac1570bf17a2e044b0e53495e61940a2c9765a09d3f6de49b989ab66019f45d4c3e5fb10c5836
+  languageName: node
+  linkType: hard
+
+"@hyperledger/indy-vdr-shared@patch:@hyperledger/indy-vdr-shared@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch":
+  version: 0.2.2
+  resolution: "@hyperledger/indy-vdr-shared@patch:@hyperledger/indy-vdr-shared@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch::version=0.2.2&hash=4d1d6e"
+  checksum: 10c0/ae7f65d1572e4bc72bea6574ea5eb6ad00818ad5d77802c849828763c9e6dc2a49cc27b7757269fb3d53374556d2a203222b153289f31ebc337120bd0f91f5d1
   languageName: node
   linkType: hard
 
@@ -5577,8 +5598,8 @@ __metadata:
     "@hyperledger/anoncreds-shared": "npm:0.2.2"
     "@hyperledger/aries-askar-nodejs": "npm:0.2.1"
     "@hyperledger/aries-askar-shared": "npm:0.2.1"
-    "@hyperledger/indy-vdr-nodejs": "npm:0.2.2"
-    "@hyperledger/indy-vdr-shared": "npm:0.2.2"
+    "@hyperledger/indy-vdr-nodejs": "patch:@hyperledger/indy-vdr-nodejs@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-nodejs-npm-0.2.2-2e02c2a0aa.patch"
+    "@hyperledger/indy-vdr-shared": "patch:@hyperledger/indy-vdr-shared@npm%3A0.2.2#~/.yarn/patches/@hyperledger-indy-vdr-shared-npm-0.2.2-b989282fc6.patch"
     "@nestjs/cli": "npm:^10.0.0"
     "@nestjs/common": "npm:^10.3.9"
     "@nestjs/core": "npm:^10.3.9"


### PR DESCRIPTION
Added patch to indy-vdr modules to configure for nodejs.
Caching functionality is confirmed to be working.
The current default caching config is 1000 entries for 1 week