### PR TITLE
feat: made cache object configurable from setupAgent

### DIFF
--- a/src/helpers/agent.ts
+++ b/src/helpers/agent.ts
@@ -44,11 +44,6 @@ export function setupAgent(options: {
   networks: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]]
   logger?: Logger
 }) {
-  indyVdr.setLedgerTxnCache({
-    capacity: 1000,
-    expiry_offset_ms: 1000 * 60 * 60 * 24 * 7,
-    path: '/tmp/indy-vdr-cache',
-  })
   return new Agent({
     config: {
       label: 'Indy VDR Proxy',

--- a/src/helpers/agent.ts
+++ b/src/helpers/agent.ts
@@ -43,7 +43,7 @@ export type IndyVdrProxyAgent = Agent<ReturnType<typeof getIndyVdrProxyAgentModu
 export function setupAgent(options: {
   networks: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]]
   logger?: Logger
-  cache?: { capacity: number, expiryMs: number, path?: string }
+  cache?: { capacity: number; expiryMs: number; path?: string }
 }) {
   return new Agent({
     config: {
@@ -61,9 +61,16 @@ export function setupAgent(options: {
   })
 }
 
-const getIndyVdrProxyAgentModules = (options: { networks: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]], cache?: { capacity: number, expiryMs: number, path?: string } }) => {
+const getIndyVdrProxyAgentModules = (options: {
+  networks: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]]
+  cache?: { capacity: number; expiryMs: number; path?: string }
+}) => {
   if (options.cache) {
-    indyVdr.setLedgerTxnCache({ capacity: options.cache.capacity, expiry_offset_ms: options.cache.expiryMs, path: options.cache.path })
+    indyVdr.setLedgerTxnCache({
+      capacity: options.cache.capacity,
+      expiry_offset_ms: options.cache.expiryMs,
+      path: options.cache.path,
+    })
   }
   return {
     askar: new AskarModule({


### PR DESCRIPTION
Added ability to configure vdr cache from setupAgent function.  
  
If the cache object is undefined then caching is disabled.
if the path parameter is undefined then it uses an in memory cache, 
otherwise it uses a filesystem cache at the specified path