### PR TITLE
chore: update image tags and resource allocation

### DIFF
--- a/devops/charts/server/values_dev.yaml
+++ b/devops/charts/server/values_dev.yaml
@@ -15,7 +15,7 @@ image:
   # registry: ghcr.io
   repository: bcgov/indy-vdr-proxy-server/server
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "342bdc4"
+  tag: "b340416"
 
 env:
   PORT: "3000"

--- a/devops/charts/server/values_prod.yaml
+++ b/devops/charts/server/values_prod.yaml
@@ -18,7 +18,7 @@ image:
   # registry: ghcr.io
   repository: bcgov/indy-vdr-proxy-server/server
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "342bdc4"
+  tag: "b340416"
 
 env:
   PORT: "3000"

--- a/devops/charts/server/values_prod.yaml
+++ b/devops/charts/server/values_prod.yaml
@@ -1,12 +1,12 @@
 # Default values for vdr-proxy prod deployment
 namespace: c2a2c4-prod
 
-replicaCount: 3
+replicaCount: 2
 
 autoscaling:
   enabled: true
-  minReplicas: 3
-  maxReplicas: 5
+  minReplicas: 2
+  maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
 podAnnotations: {}
@@ -29,10 +29,10 @@ env:
 resources:
   requests:
     memory: 300Mi
-    cpu: 50m
+    cpu: 40m
   limits:
     memory: 300Mi
-    cpu: 200m
+    cpu: 120m
 
 imagePullSecrets:
   - name: artifactory-regcred

--- a/devops/charts/server/values_test.yaml
+++ b/devops/charts/server/values_test.yaml
@@ -18,7 +18,7 @@ image:
   # registry: ghcr.io
   repository: bcgov/indy-vdr-proxy-server/server
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "342bdc4"
+  tag: "b340416"
 
 env:
   PORT: "3000"

--- a/devops/charts/server/values_test.yaml
+++ b/devops/charts/server/values_test.yaml
@@ -32,7 +32,7 @@ resources:
     cpu: 30m
   limits:
     memory: 300Mi
-    cpu: 200m
+    cpu: 120m
 
 imagePullSecrets:
   - name: artifactory-regcred


### PR DESCRIPTION
Updating tags and lowering the resource allocation a bit so we don't hit limits even when max pods are used