### PR TITLE
chore: bump image tags

### DIFF
--- a/devops/charts/server/values_dev.yaml
+++ b/devops/charts/server/values_dev.yaml
@@ -15,7 +15,7 @@ image:
   # registry: ghcr.io
   repository: bcgov/indy-vdr-proxy-server/server
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "b340416"
+  tag: "96989fe"
 
 env:
   PORT: "3000"

--- a/devops/charts/server/values_prod.yaml
+++ b/devops/charts/server/values_prod.yaml
@@ -18,7 +18,7 @@ image:
   # registry: ghcr.io
   repository: bcgov/indy-vdr-proxy-server/server
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "b340416"
+  tag: "96989fe"
 
 env:
   PORT: "3000"

--- a/devops/charts/server/values_test.yaml
+++ b/devops/charts/server/values_test.yaml
@@ -18,7 +18,7 @@ image:
   # registry: ghcr.io
   repository: bcgov/indy-vdr-proxy-server/server
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "b340416"
+  tag: "96989fe"
 
 env:
   PORT: "3000"


### PR DESCRIPTION
These image tags are already in use now and working as expected, just updating them in the repo as well